### PR TITLE
Add minimal alertmanager config

### DIFF
--- a/vol/config/alertmanager-generated.yml
+++ b/vol/config/alertmanager-generated.yml
@@ -1,4 +1,6 @@
+global:
+  resolve_timeout: 5m
 route:
-  receiver: devnull
+  receiver: 'null'
 receivers:
-  - name: devnull
+  - name: 'null'


### PR DESCRIPTION
## Summary
- ensure Alertmanager has basic configuration so Docker health checks pass

## Testing
- `docker compose -f local_cluster.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ad498e2c78833086433f911e2e1dd9