### PR TITLE
Disable ksqlDB metrics and align Connect configuration

### DIFF
--- a/local_cluster.yml
+++ b/local_cluster.yml
@@ -69,7 +69,7 @@ services:
       SCHEMA_REGISTRY_LOG4J_ROOT_LOGLEVEL: WARN
 
   connect:
-    image: cnfldemos/cp-server-connect-datagen:0.6.4-7.6.0
+    image: confluentinc/cp-kafka-connect:8.0.0
     hostname: connect
     container_name: connect
     depends_on:
@@ -95,8 +95,10 @@ services:
       CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-8.0.0.jar
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
-      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components"
+      CONNECT_PLUGIN_PATH: "/usr/share/java,/usr/share/confluent-hub-components,/etc/kafka-connect/jars"
       CONNECT_LOG4J_ROOT_LOGLEVEL: WARN
+    volumes:
+      - ./vol/connect/jars:/etc/kafka-connect/jars
 
   prometheus:
     image: confluentinc/cp-enterprise-prometheus:2.2.0
@@ -200,7 +202,7 @@ services:
     networks: [confluentnet]
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
-      KSQL_BOOTSTRAP_SERVERS: "broker:29092"
+      KSQL_BOOTSTRAP_SERVERS: "broker:9092"
       KSQL_HOST_NAME: ksqldb-server
       KSQL_LISTENERS: "http://0.0.0.0:8088"
       KSQL_CACHE_MAX_BYTES_BUFFERING: 0
@@ -212,6 +214,7 @@ services:
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: 'true'
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: 'true'
       KSQL_LOG4J_ROOT_LOGLEVEL: WARN
+      KSQL_CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
 
   ksqldb-cli:
     image: confluentinc/cp-ksqldb-cli:8.0.0

--- a/vol/connect/jars/README.md
+++ b/vol/connect/jars/README.md
@@ -1,0 +1,1 @@
+Place required Kafka Connect plugin jar dependencies in this directory.


### PR DESCRIPTION
## Summary
- disable Confluent support metrics in ksqlDB and update broker bootstrap port
- update Kafka Connect to CP 8.0.0 with extra plugin jar path

## Testing
- `python - <<'PY'
import yaml
with open('local_cluster.yml') as f:
    yaml.safe_load(f)
print('YAML parsed')
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml >/tmp/pip.log && tail -n 20 /tmp/pip.log` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_b_68ad81f50a3c8330a7b2e1ba0bfbb753