### PR TITLE
Add Terraform GitHub Actions workflow with apply/destroy jobs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,234 @@
+name: Terraform MSK Pipeline
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.tf'
+      - '.github/workflows/terraform.yml'
+  pull_request:
+    paths:
+      - '**/*.tf'
+      - '.github/workflows/terraform.yml'
+  workflow_dispatch:
+    inputs:
+      tf_action:
+        description: Terraform action to run
+        type: choice
+        options:
+          - validate
+          - apply
+          - destroy
+        default: validate
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TERRAFORM_VERSION: 1.6.6
+  TF_WORKING_DIR: .
+  PLAN_FILE: plan.out
+  TF_VARS_FILE: ci.auto.tfvars
+  AWS_REGION: ap-south-1
+
+jobs:
+  validate:
+    name: Validate configuration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Configure AWS credentials (OIDC)
+        if: secrets.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || env.AWS_REGION }}
+
+      - name: Materialize tfvars from secret
+        if: secrets.TERRAFORM_TFVARS != ''
+        run: |
+          cat <<'VARS' > ${{ env.TF_VARS_FILE }}
+${{ secrets.TERRAFORM_TFVARS }}
+VARS
+
+      - name: Terraform fmt
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} fmt -check -recursive
+
+      - name: Terraform init
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} init -upgrade -input=false
+
+      - name: Terraform validate
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} validate
+
+      - name: Terraform plan
+        run: |
+          if [ -f "${{ env.TF_VARS_FILE }}" ]; then
+            terraform -chdir=${{ env.TF_WORKING_DIR }} plan -input=false -out="${{ env.PLAN_FILE }}" -var-file="${{ env.TF_VARS_FILE }}"
+          else
+            terraform -chdir=${{ env.TF_WORKING_DIR }} plan -input=false -out="${{ env.PLAN_FILE }}"
+          fi
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-plan
+          path: ${{ env.PLAN_FILE }}
+
+  terraform-init:
+    name: Terraform initialization check
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Configure AWS credentials (OIDC)
+        if: secrets.AWS_ROLE_ARN != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || env.AWS_REGION }}
+
+      - name: Materialize tfvars from secret
+        if: secrets.TERRAFORM_TFVARS != ''
+        run: |
+          cat <<'VARS' > ${{ env.TF_VARS_FILE }}
+${{ secrets.TERRAFORM_TFVARS }}
+VARS
+
+      - name: Terraform init (no upgrade)
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} init -input=false
+
+  apply:
+    name: Apply infrastructure
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - terraform-init
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tf_action == 'apply'
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || env.AWS_REGION }}
+
+      - name: Download plan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-plan
+
+      - name: Terraform init
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} init -input=false
+
+      - name: Terraform apply
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} apply -input=false -auto-approve "${{ env.PLAN_FILE }}"
+
+      - name: Capture outputs
+        run: |
+          terraform -chdir=${{ env.TF_WORKING_DIR }} output -json > terraform-outputs.json
+          terraform -chdir=${{ env.TF_WORKING_DIR }} output > terraform-outputs.txt
+
+      - name: Upload outputs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-outputs
+          path: |
+            terraform-outputs.json
+            terraform-outputs.txt
+
+  report:
+    name: Report created infrastructure
+    runs-on: ubuntu-latest
+    needs: apply
+    if: needs.apply.result == 'success'
+    steps:
+      - name: Download outputs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: terraform-outputs
+
+      - name: Publish outputs to summary
+        run: |
+          {
+            echo '### Terraform Outputs';
+            echo '';
+            cat terraform-outputs.txt;
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload outputs as job artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-outputs-report
+          path: |
+            terraform-outputs.json
+            terraform-outputs.txt
+
+  destroy:
+    name: Destroy infrastructure
+    runs-on: ubuntu-latest
+    needs:
+      - terraform-init
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.tf_action == 'destroy'
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION != '' && secrets.AWS_REGION || env.AWS_REGION }}
+
+      - name: Materialize tfvars from secret
+        if: secrets.TERRAFORM_TFVARS != ''
+        run: |
+          cat <<'VARS' > ${{ env.TF_VARS_FILE }}
+${{ secrets.TERRAFORM_TFVARS }}
+VARS
+
+      - name: Terraform init
+        run: terraform -chdir=${{ env.TF_WORKING_DIR }} init -input=false
+
+      - name: Terraform destroy
+        run: |
+          if [ -f "${{ env.TF_VARS_FILE }}" ]; then
+            terraform -chdir=${{ env.TF_WORKING_DIR }} destroy -auto-approve -input=false -var-file="${{ env.TF_VARS_FILE }}"
+          else
+            terraform -chdir=${{ env.TF_WORKING_DIR }} destroy -auto-approve -input=false
+          fi


### PR DESCRIPTION
## Summary
- add a Terraform GitHub Actions workflow with dedicated validate, initialization, apply, report, and destroy jobs
- document how to configure the new workflow and required secrets in the CI/CD guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d2851d3af48330b1452402d2e475e8